### PR TITLE
fix: 使用Trae AI 更新GitHub Actions输出语法以兼容新版本

### DIFF
--- a/.github/workflows/LabVIEW Project Tests.yml
+++ b/.github/workflows/LabVIEW Project Tests.yml
@@ -23,5 +23,6 @@ jobs:
       - name: Run lvCICD Test cases with VITester
         uses: NEVSTOP-LAB/lvCICD@main
         with:
+          LabVIEW_Version: 2017
           Operation: StartVITester
           Parameter1: ${{ github.workspace }}\LabVIEW-Adapter\CICD-LabVIEW-Adapter.lvproj

--- a/action.yml
+++ b/action.yml
@@ -106,5 +106,5 @@ runs:
         $Parameter9 `
         $Parameter10 ;
         $Result=Get-Content -Path "${{ github.action_path }}\output.txt";
-        Write-Host "::set-output name=Result::$Result"
+        echo "Result=$Result" >> $env:GITHUB_OUTPUT
       shell: powershell

--- a/docs/examples/Build_VIPM_Library.yml
+++ b/docs/examples/Build_VIPM_Library.yml
@@ -36,7 +36,7 @@ jobs:
       - id: vip-name
         run:
           $vipName=Split-Path -Path ${{ steps.build-vip.outputs.Result }} -Leaf;
-          Write-Host "::set-output name=vipName::"$vipName""
+          echo "vipName=$vipName" >> $env:GITHUB_OUTPUT
         shell: powershell
 
       - name: Upload a Build Artifact


### PR DESCRIPTION
将`::set-output`命令替换为`echo "name=value" >> $env:GITHUB_OUTPUT`语法